### PR TITLE
피그마 주소를 추가합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,8 @@ export default {
 - Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
 - Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
 - Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+
+# UI/UX Repository
+Desktop: https://www.figma.com/file/XJxcuynH5T0CZTmGHNTSxT/desktop?type=design&t=Y8hAgNTIkWnQCtKY-6
+Mobile: https://www.figma.com/file/kHnnikCD384Cb6KpgsALe6/mobile?type=design&t=Y8hAgNTIkWnQCtKY-6
+Board: https://www.figma.com/file/pW8DReLCOIOqVMsaWIWb53/board?type=whiteboard&t=Y8hAgNTIkWnQCtKY-6


### PR DESCRIPTION
`Read.md`에 디자인 리포지토리의 바로가기를 추가합니다.

## #️⃣연관된 이슈
[issue-5 피그마 주소를 `read.md`에 추가합니다.](https://github.com/SSA-FE/formssafe-fe/issues/5)

## 📝작업 내용
Read.md에 피그마 주소를 기록했습니다. 매우 단순한 변동입니다. 이를 통해 디자인 리포지토리를 독자에게 보여주거나 빠른 바로가기로써 사용할 수 있습니다.