### PR TITLE
Feat/#46 마이스페이스 페이지 - 내가 작성한 설문 리스트 표시

### DIFF
--- a/src/api/activityApi.ts
+++ b/src/api/activityApi.ts
@@ -21,6 +21,7 @@ interface Reward {
 export interface Survey {
   id: number;
   title: string;
+  description: string;
   thumbnail: string;
   author: Author;
   expectTime: number;

--- a/src/api/activityApi.ts
+++ b/src/api/activityApi.ts
@@ -1,0 +1,59 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { BASE_URL, API } from '@/config';
+
+interface Tag {
+  id: number;
+  name: string;
+  count: number;
+}
+
+interface Author {
+  userId: number;
+  nickname: string;
+}
+
+interface Reward {
+  name: string;
+  category: string;
+  count: number;
+}
+
+export interface Survey {
+  id: number;
+  title: string;
+  thumbnail: string;
+  author: Author;
+  expectTime: number;
+  questionCnt: number;
+  responseCnt: number;
+  startDate: string;
+  endDate: string;
+  reward: Reward;
+  tags: Tag[];
+  status: string;
+  isTemp: boolean;
+}
+
+interface SurveyResponse {
+  surveys: Survey[];
+}
+
+export const activityApi = createApi({
+  reducerPath: 'activityApi',
+  baseQuery: fetchBaseQuery({ baseUrl: BASE_URL, credentials: 'include' }),
+  endpoints: (builder) => ({
+    fetchParticipatedSurveys: builder.query<SurveyResponse, void>({
+      query: () => ({ url: `${API.ACTIVITY}/responses` }),
+    }),
+    fetchRegisteredSurveys: builder.query<SurveyResponse, void>({
+      query: () => ({
+        url: `${API.ACTIVITY}/forms`,
+      }),
+    }),
+  }),
+});
+
+export const {
+  useFetchParticipatedSurveysQuery,
+  useFetchRegisteredSurveysQuery,
+} = activityApi;

--- a/src/components/Myspace/SortDropdown.tsx
+++ b/src/components/Myspace/SortDropdown.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import dropdownIcon from '@/assets/icons/dropdown-icon.svg';
 
 const SortDropdown = () => {
-  const options = ['최근에 수정된 순서', '많은 응답자순', '가까운 마감일자순'];
+  const options = ['생성일순', '응답자순', '가까운 마감순'];
 
   const [isOpen, setIsOpen] = useState(false);
   const [selectedOption, setSelectedOption] = useState(options[0]);

--- a/src/components/Myspace/SurveyCard.tsx
+++ b/src/components/Myspace/SurveyCard.tsx
@@ -1,19 +1,38 @@
 import TempSaveIcon from '@/assets/icons/temp-save-icon.svg?react';
 
-interface ISurveyCard {
-  tags?: string[];
+interface Tag {
+  id: number;
+  name: string;
+  count: number;
+}
+
+interface SurveyCardProps {
+  title: string;
+  // TODO: description 추가
+  tags?: Tag[];
   questionCnt: number;
   expectTime: number;
+  startDate: string;
   isTemp: boolean;
 }
 
-const SurveyCard = ({ tags, questionCnt, expectTime, isTemp }: ISurveyCard) => {
+const SurveyCard = ({
+  title,
+  tags,
+  questionCnt,
+  expectTime,
+  startDate,
+  isTemp,
+}: SurveyCardProps) => {
+  const dateObject = new Date(startDate);
+  const formattedDate = `${dateObject.getFullYear()}/${String(dateObject.getMonth() + 1).padStart(2, '0')}/${String(dateObject.getDate()).padStart(2, '0')}`;
+
   return (
     <div className="w-full border rounded-lg max-w-surveyCard border-neutral-300">
       <div className="flex items-center justify-between w-full gap-2 px-5 pt-4 pb-[10px] border-neutral-300 border-b-[1px]">
         <div className="flex items-center gap-x-2">
           <h1 className="text-base font-bold text-neutral-600 whitespace-nowrap">
-            좋아하는 음식
+            {title}
           </h1>
           {isTemp && (
             <p className="w-[14px] h-[14px]">
@@ -23,7 +42,7 @@ const SurveyCard = ({ tags, questionCnt, expectTime, isTemp }: ISurveyCard) => {
         </div>
 
         <h2 className="gap-4 text-xs font-normal hmm text-neutral-400 whitespace-nowrap">
-          LastEdit on 2023/02/16
+          LastEdit on {formattedDate}
         </h2>
       </div>
       <div className="flex flex-col p-4 gap-y-4">
@@ -35,23 +54,19 @@ const SurveyCard = ({ tags, questionCnt, expectTime, isTemp }: ISurveyCard) => {
           <p>
             <strong>문항수</strong>&nbsp;{questionCnt}
             개&nbsp;
-            <strong>소요시간</strong>&nbsp;30분
           </p>
           <p>
-            <strong>예상시간</strong>&nbsp;{expectTime}초
-          </p>
-          <p>
-            <strong>임시저장본</strong>
+            <strong>예상소요시간</strong>&nbsp;{expectTime}분
           </p>
         </div>
         <div className="flex h-6 gap-x-2">
           {tags?.map((tag) => {
             return (
               <span
-                key={tag}
+                key={tag.id}
                 className="flex items-center justify-center px-3 text-xs font-bold cursor-pointer whitespace-nowrap text-neutral-100 bg-neutral-500 rounded-xl"
               >
-                #{tag}
+                #{tag.name}
               </span>
             );
           })}

--- a/src/components/Myspace/SurveyCard.tsx
+++ b/src/components/Myspace/SurveyCard.tsx
@@ -8,7 +8,7 @@ interface Tag {
 
 interface SurveyCardProps {
   title: string;
-  // TODO: description 추가
+  description: string;
   tags?: Tag[];
   questionCnt: number;
   expectTime: number;
@@ -18,6 +18,7 @@ interface SurveyCardProps {
 
 const SurveyCard = ({
   title,
+  description,
   tags,
   questionCnt,
   expectTime,
@@ -47,8 +48,7 @@ const SurveyCard = ({
       </div>
       <div className="flex flex-col p-4 gap-y-4">
         <p className="px-2 text-sm font-normal text-neutral-500">
-          좋아하는 음식을 설문조사해서 맛있는 음식을 판매합니다. 사람들이
-          좋아하는 음식은 무엇일까요?
+          {description}
         </p>
         <div className="flex flex-col px-4 py-2 text-xs border rounded-lg border-neutral-200 gap-y-1 text-neutral-400">
           <p>

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,6 @@ export const API = {
   USERS: `/api/v1/users`,
   FORM: `/api/v1/forms`,
   RESULT: `/api/v1/forms`,
-  ACTIVITY: `/api/v1/activities`,
+  ACTIVITY: `/api/v1/activity`,
   SUBMISSION: `/api/v1/forms`,
 };

--- a/src/pages/Myspace.tsx
+++ b/src/pages/Myspace.tsx
@@ -1,9 +1,26 @@
+import { useFetchRegisteredSurveysQuery } from '@/api/activityApi';
+import SurveyCard from '@/components/Myspace/SurveyCard';
 import Toolbar from '@/components/Myspace/Toolbar';
+import { Survey } from '@/api/activityApi';
 
 const Myspace = () => {
+  const { data: MySurveyList, isLoading } = useFetchRegisteredSurveysQuery();
+  console.log(MySurveyList);
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <>
       <Toolbar />
+      <div className="flex flex-wrap">
+        {MySurveyList &&
+          Array.isArray(MySurveyList) &&
+          MySurveyList.map((survey: Survey) => (
+            <SurveyCard key={survey.id} {...survey} />
+          ))}
+      </div>
     </>
   );
 };

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,14 +1,19 @@
 import { configureStore } from '@reduxjs/toolkit';
 import questionBlockListReducer from '@/components/Myspace/questionBlockList/questionBlockListSlice';
 import { userApi } from '@api/userApi';
+import { activityApi } from '@/api/activityApi';
 
 export const store = configureStore({
   reducer: {
     questionBlockList: questionBlockListReducer,
     [userApi.reducerPath]: userApi.reducer,
+    [activityApi.reducerPath]: activityApi.reducer,
   },
   middleware: (getDefaultMiddleware) => {
-    return getDefaultMiddleware().concat(userApi.middleware);
+    return getDefaultMiddleware().concat(
+      userApi.middleware,
+      activityApi.middleware
+    );
   },
 });
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #46 

## 📝작업 내용

> 마이스페이스에 내가 작성한 설문 리스트를 표시하는 것을 목표로 작업을 진행습니다. 
이번 이슈에선 크게 두 가지 작업을 진행했습니다. 
> 1. activity와 관련한 api를 만들어 store에 등록했습니다. api 카테고리 별로 api를 나누어 작업하면 프론트쪽에서도 관련 코드를 찾기 수월해보여서 적용해봤습니다.
> 2. 마이스페이스에 MySurveyList로 data를 받아 화면에 렌더링했습니다. 해당 작업 중 api상에서 누락된 변수가 있어서 백엔드 측에 요청해 추가했습니다. 
> 다음 issue로 마이스페이스의 디자인 작업을 진행할 예정입니다. 카드의 내용이나 드롭다운의 옵션명등 열받는 디자인 요소가 곳곳에 있어서 제 입맛대로 바꾸고 있으니 피그마랑 일부 내용이 달라도 놀라진 말아주세요 :D 

### 스크린샷 (선택)
![image](https://github.com/SSA-FE/formssafe-fe/assets/87296259/eaa5645f-4a5d-42ec-ae1e-838f520cdf35)
<fig 1. 내가 등록한 리스트 렌더링(디자인 및 세부사항은 이후 이슈로..)>

## 💬리뷰 요구사항(선택)
> swagger상의 api 카테고리 별로 프론트에서도 api를 분류하면 어떨까 생각중입니다 ! (api/activityApi.ts)
> 생각보다 rtk query만 써도 해결되는 경우가 많아서 rtk와 rtk query 사용이 고민될때는 rtk query 먼저 고민해봐도 좋을 거 같다고 생각중인데 작성한 코드를 보고 의견 주시면 좋을거같습니당 :)
