### PR TITLE
fix: 폰트 적용 이슈 해결

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,16 +7,6 @@
       type="image/svg+xml"
       href="https://cdn-icons-png.flaticon.com/512/5175/5175820.png"
     />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@700&display=swap"
-      rel="stylesheet"
-    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>폼나는 싸패</title>
   </head>

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,11 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 * {
-  font-family:
-    'Inter',
-    Trebuchet MS,
-    sans-serif !important;
   scrollbar-width: thin;
   scrollbar-color: #d9d9d9 #fff;
 }
@@ -36,6 +35,12 @@
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+}
+
+@layer base {
+  html {
+    font-family: 'Noto Sans KR', 'Inter', sans-serif;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #81 

## 📝작업 내용

> 기존 프로젝트는 inter 폰트를 적용하는 형식으로 진행했습니다. 이는 피그마 설정을 그대로 따라간 것입니다. 하지만 대부분의 인원들이 알다시피 inter 폰트가 제대로 적용되지 않고 있습니다. 해당 원인을 분석한 결과 다음과 같은 이슈를 알 수 있었습니다.
> 1. inter 폰트는 한글을 지원하고 있지 않습니다.
> 2. inter 폰트에 대한 한글 대안으로 pretendard를 많은 사람들이 추천하고 있습니다.
> 3. 피그마에선 기본적으로 영문과 숫자에 대해선 inter 폰트를 적용하고 있지만, inter 폰트가 적용되지 않는 한글에 대해선 Noto Sans 폰트를 사용하고 있습니다. 하지만 이는 피그마 설정상에선 드러나고 있지 않습니다.

> 해당 이슈를 바탕으로 index.css 설정을 바꾸어 한글에 대해선 Noto Sans를, 영문에 대해선 inter를 적용하도록 설정을 변경하였습니다. 결과적으로 현재는 피그마 디자인과 동일한 폰트가 적용되고 있습니다. 
