### PR TITLE
Chore/#71 boardViewSlice 세팅 및 적용

### DIFF
--- a/src/api/viewApi.ts
+++ b/src/api/viewApi.ts
@@ -54,7 +54,10 @@ interface FormRequest {
   category?: string[];
   status?: string;
   tag?: string[];
-  page?: number;
+  top?: number;
+  startDate?: string;
+  endDate?: string;
+  responseCnt?: number;
 }
 
 export const viewApi = createApi({

--- a/src/components/Board/boardViewSlice.ts
+++ b/src/components/Board/boardViewSlice.ts
@@ -1,0 +1,82 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+interface ViewRequest {
+  keyword?: string;
+  sort?: string;
+  category?: string[];
+  status?: string;
+  tag?: string[];
+  top?: number;
+  startDate?: string;
+  endDate?: string;
+  responseCnt?: number;
+}
+
+const initialState: ViewRequest = {
+  keyword: '',
+  sort: 'createdtime',
+  category: [''],
+  status: '',
+  tag: [],
+  top: 0,
+  startDate: '',
+  endDate: '',
+  responseCnt: 0,
+};
+
+export const boardViewSlice = createSlice({
+  name: 'boardView',
+  initialState,
+  reducers: {
+    setKeyword: (state, action: PayloadAction<string>) => {
+      state.keyword = action.payload;
+    },
+    setSort: (state, action: PayloadAction<string>) => {
+      state.sort = action.payload;
+    },
+    setCategory: (state, action: PayloadAction<string>) => {
+      state.category = [action.payload];
+    },
+    setStatus: (state, action: PayloadAction<string>) => {
+      state.status = action.payload;
+    },
+    setTag: (state, action: PayloadAction<string>) => {
+      if (!state.tag) {
+        state.tag = [];
+      }
+      state.tag.push(action.payload);
+    },
+    removeTag: (state, action: PayloadAction<string>) => {
+      if (!state.tag) {
+        state.tag = [];
+      }
+      state.tag = state.tag.filter((tag) => tag !== action.payload);
+    },
+    setTop: (state, action: PayloadAction<number>) => {
+      state.top = action.payload;
+    },
+    setStartDate: (state, action: PayloadAction<string>) => {
+      state.startDate = action.payload;
+    },
+    setEndDate: (state, action: PayloadAction<string>) => {
+      state.endDate = action.payload;
+    },
+    setResponseCnt: (state, action: PayloadAction<number>) => {
+      state.responseCnt = action.payload;
+    },
+  },
+});
+
+export const {
+  setKeyword,
+  setSort,
+  setCategory,
+  setStatus,
+  setTag,
+  removeTag,
+  setTop,
+  setStartDate,
+  setEndDate,
+  setResponseCnt,
+} = boardViewSlice.actions;
+export default boardViewSlice.reducer;

--- a/src/components/Board/main/BoardToolbar.tsx
+++ b/src/components/Board/main/BoardToolbar.tsx
@@ -1,11 +1,26 @@
 import { useState } from 'react';
+import { setSort } from '@components/Board/boardViewSlice';
 import CategoryDropdown from './CategoryDropdown';
 import StatusDropdown from './StatusDropdown';
+import { useAppDispatch } from '@hooks/useAppDispatch';
 
 const BoardToolbar = () => {
   const [activeTap, setActiveTap] = useState('최근에 작성된 설문지');
   const [isStatusDropdownOpen, setStatusDropdownOpen] = useState(false);
   const [isCategoryDropdownOpen, setCategoryDropdownOpen] = useState(false);
+  const dispatch = useAppDispatch();
+
+  const tapList = ['최근에 작성된 설문지', '인기있는 설문지', '마감임박'];
+  const formTapCodes: { [key: string]: string } = {
+    '최근에 작성된 설문지': 'createdtime',
+    '인기있는 설문지': 'responseCnt',
+    마감임박: 'endTime',
+  };
+
+  const handleTap = (tap: string) => {
+    setActiveTap(tap);
+    dispatch(setSort(formTapCodes[tap]));
+  };
 
   const handleStatusDropdown = () => {
     setCategoryDropdownOpen(false);
@@ -20,30 +35,15 @@ const BoardToolbar = () => {
   return (
     <div className="flex items-center justify-between w-full h-12 ">
       <div className="flex min-w-[480px] h-full space-x-4 font-bold bg-transparent border-none text-sm">
-        <button
-          className={`px-6 py-3  ${activeTap === '최근에 작성된 설문지' ? 'border-b-2 border-blue-300 text-slate-600' : 'text-slate-400 border-none'}`}
-          onClick={() => {
-            setActiveTap('최근에 작성된 설문지');
-          }}
-        >
-          최근에 작성된 설문지
-        </button>
-        <button
-          className={`px-6 py-2 ${activeTap === '인기있는 설문지' ? 'border-b-2  border-blue-300 text-slate-600' : 'text-slate-400 border-none'}`}
-          onClick={() => {
-            setActiveTap('인기있는 설문지');
-          }}
-        >
-          인기있는 설문지
-        </button>
-        <button
-          className={`px-6 py-2 ${activeTap === '마감임박' ? 'border-b-2  border-blue-300 text-slate-600' : 'text-slate-400 border-none'}`}
-          onClick={() => {
-            setActiveTap('마감임박');
-          }}
-        >
-          마감임박
-        </button>
+        {tapList.map((tap) => (
+          <button
+            key={tap}
+            className={`px-6 py-3 ${activeTap === tap ? 'border-b-2 border-blue-300 text-slate-600' : 'text-slate-400 border-none'}`}
+            onClick={() => handleTap(tap)}
+          >
+            {tap}
+          </button>
+        ))}
       </div>
       <div className="w-[340px] h-10 flex justify-between mb-4">
         <StatusDropdown

--- a/src/components/Board/main/CategoryDropdown.tsx
+++ b/src/components/Board/main/CategoryDropdown.tsx
@@ -1,15 +1,18 @@
 import { CategoryListIcon } from '@/assets/icons';
 import { useEffect, useRef, useState } from 'react';
+import { useAppDispatch } from '@hooks/useAppDispatch';
+import { setCategory } from '@components/Board/boardViewSlice';
 
 interface CategoryDropdownProps {
   isOpen: boolean;
   handleDropdown: () => void;
 }
 
-const CategoryDropdown = ({
+const CategoryDropdown: React.FC<CategoryDropdownProps> = ({
   isOpen,
   handleDropdown,
-}: CategoryDropdownProps) => {
+}) => {
+  const dispatch = useAppDispatch();
   const dropdownRef = useRef<HTMLButtonElement>(null);
   const categoryList = [
     '커피/음료',
@@ -31,18 +34,19 @@ const CategoryDropdown = ({
 
   useEffect(() => {
     if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('click', handleClickOutside);
     } else {
-      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('click', handleClickOutside);
     }
 
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('click', handleClickOutside);
     };
   }, [isOpen]);
 
   const handleSelectCategory = (category: string) => {
     setSelectedCategory(category);
+    dispatch(setCategory(category));
     handleDropdown();
   };
 

--- a/src/components/Board/main/StatusDropdown.tsx
+++ b/src/components/Board/main/StatusDropdown.tsx
@@ -1,4 +1,6 @@
 import { StatusIcon } from '@/assets/icons';
+import { useAppDispatch } from '@hooks/useAppDispatch';
+import { setStatus } from '@components/Board/boardViewSlice';
 import { useEffect, useRef, useState } from 'react';
 
 interface StatusDropdownProps {
@@ -6,9 +8,18 @@ interface StatusDropdownProps {
   handleDropdown: () => void;
 }
 
-const StatusDropdown = ({ isOpen, handleDropdown }: StatusDropdownProps) => {
+const StatusDropdown: React.FC<StatusDropdownProps> = ({
+  isOpen,
+  handleDropdown,
+}) => {
+  const dispatch = useAppDispatch();
   const dropdownRef = useRef<HTMLButtonElement>(null);
   const statusList = ['전체 설문', '진행중인 설문', '마감된 설문'];
+  const formStatusCodes: { [key: string]: string } = {
+    '전체 설문': '',
+    '진행중인 설문': 'progress',
+    '마감된 설문': 'done',
+  };
   const [, setSelectedOption] = useState(statusList[0]);
 
   const handleClickOutside = (event: MouseEvent) => {
@@ -22,18 +33,19 @@ const StatusDropdown = ({ isOpen, handleDropdown }: StatusDropdownProps) => {
 
   useEffect(() => {
     if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('click', handleClickOutside);
     } else {
-      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('click', handleClickOutside);
     }
 
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('click', handleClickOutside);
     };
   }, [isOpen]);
 
   const handleSelectStatus = (status: string) => {
     setSelectedOption(status);
+    dispatch(setStatus(formStatusCodes[status]));
     handleDropdown();
   };
 

--- a/src/components/Board/panel/SearchForm.tsx
+++ b/src/components/Board/panel/SearchForm.tsx
@@ -1,12 +1,10 @@
 import { SearchIcon } from '@/assets/icons';
-import { useState, KeyboardEvent, ChangeEvent, useEffect } from 'react';
+import { useState, KeyboardEvent, ChangeEvent } from 'react';
 import {
   setKeyword,
   setTag,
   removeTag,
 } from '@components/Board/boardViewSlice';
-import { useSelector } from 'react-redux';
-import { RootState } from '@/store';
 import { useAppDispatch } from '@hooks/useAppDispatch';
 
 interface Tag {
@@ -17,14 +15,7 @@ interface Tag {
 const SearchForm = () => {
   const [input, setInput] = useState('');
   const [tags, setTags] = useState<Tag[]>([]);
-
   const dispatch = useAppDispatch();
-
-  const boardView = useSelector((state: RootState) => state.boardView);
-
-  useEffect(() => {
-    console.log(boardView);
-  }, [boardView]);
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     setInput(e.target.value);

--- a/src/components/Board/panel/SearchForm.tsx
+++ b/src/components/Board/panel/SearchForm.tsx
@@ -1,5 +1,13 @@
 import { SearchIcon } from '@/assets/icons';
-import { useState, KeyboardEvent, ChangeEvent } from 'react';
+import { useState, KeyboardEvent, ChangeEvent, useEffect } from 'react';
+import {
+  setKeyword,
+  setTag,
+  removeTag,
+} from '@components/Board/boardViewSlice';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/store';
+import { useAppDispatch } from '@hooks/useAppDispatch';
 
 interface Tag {
   id: number;
@@ -10,25 +18,48 @@ const SearchForm = () => {
   const [input, setInput] = useState('');
   const [tags, setTags] = useState<Tag[]>([]);
 
+  const dispatch = useAppDispatch();
+
+  const boardView = useSelector((state: RootState) => state.boardView);
+
+  useEffect(() => {
+    console.log(boardView);
+  }, [boardView]);
+
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     setInput(e.target.value);
   };
 
   const addTag = (text: string) => {
     setTags([...tags, { id: Date.now(), text }]);
-    setInput('');
   };
 
-  const removeTag = (id: number) => {
+  const removeTagFromState = (id: number) => {
     setTags(tags.filter((tag) => tag.id !== id));
+
+    const tagToRemove = tags.find((tag) => tag.id === id);
+    if (!tagToRemove) return;
+
+    const sanitizedInput = tagToRemove.text.slice(1).replace(/\s/g, '');
+    dispatch(removeTag(sanitizedInput));
   };
 
   const handleInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       e.preventDefault();
+      if (input.startsWith('#') && tags.some((tag) => tag.text === input)) {
+        setInput('');
+        return;
+      }
+
       if (input.startsWith('#')) {
         addTag(input);
+        const sanitizedInput = input.slice(1).replace(/\s/g, '');
+        dispatch(setTag(sanitizedInput));
+      } else {
+        dispatch(setKeyword(input));
       }
+      setInput('');
     }
   };
 
@@ -43,7 +74,7 @@ const SearchForm = () => {
       (e.type === 'keydown' &&
         (e as React.KeyboardEvent<HTMLButtonElement>).key === 'Enter')
     ) {
-      removeTag(id);
+      removeTagFromState(id);
     }
   };
 
@@ -55,7 +86,7 @@ const SearchForm = () => {
       {tags.map((tag) => (
         <button
           key={tag.id}
-          className="flex items-center justify-center text-xs font-bold rounded-xl text-slate-200 bg-slate-400 py-0 px-2 h-6 cursor-pointer whitespace-nowrap"
+          className="flex items-center justify-center h-6 px-2 py-0 text-xs font-bold cursor-pointer rounded-xl text-slate-200 bg-slate-400 whitespace-nowrap"
           onClick={(e) => handleTagInteraction(tag.id, e)}
           onKeyDown={(e) => handleTagInteraction(tag.id, e)}
         >

--- a/src/components/Myspace/FormMain.tsx
+++ b/src/components/Myspace/FormMain.tsx
@@ -1,12 +1,12 @@
 import plusIcon from '@/assets/icons/plus-icon.svg';
 import QuestionBlockList from './questionBlockList/QuestionBlockList';
 import { addQuestion } from './questionBlockList/questionBlockListSlice';
-import { useDispatch } from 'react-redux';
+import { useAppDispatch } from '@hooks/useAppDispatch';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/store';
 
 const FormMain = () => {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const questionBlock = useSelector((store: RootState) => store.questionBlock);
 
   const handleAddBlock = () => {

--- a/src/components/Myspace/MyspacePanel.tsx
+++ b/src/components/Myspace/MyspacePanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { resetInput } from './toolbar/toolbarInputSlice';
-import { useDispatch } from 'react-redux';
+import { useAppDispatch } from '@/hooks/useAppDispatch';
 
 interface MyspacePanelProps {
   setSurveyStatus: (value: string) => void;
@@ -9,7 +9,7 @@ interface MyspacePanelProps {
 
 const MyspacePanel = ({ setSurveyStatus }: MyspacePanelProps) => {
   const [activeTap, setActiveTap] = useState('보관함');
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   return (
     <div className="flex flex-col px-8 items-start space-y-2 border-b-[1px] bg-white">

--- a/src/components/Myspace/SearchBar.tsx
+++ b/src/components/Myspace/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { SearchIcon } from '@/assets/icons';
 import { updateKeyword } from '@components/Myspace/toolbar/toolbarInputSlice';
 import { useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useAppDispatch } from '@hooks/useAppDispatch';
 
 interface SearchBarProps {
   placeholder: string;
@@ -11,7 +11,7 @@ interface SearchBarProps {
 }
 
 const SearchBar = ({ placeholder, bgColor, width, height }: SearchBarProps) => {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const [keyword, setKeyword] = useState('');
 
   const handleOnclick = () => {

--- a/src/components/Myspace/SortDropdown.tsx
+++ b/src/components/Myspace/SortDropdown.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import dropdownIcon from '@/assets/icons/dropdown-icon.svg';
-import { useDispatch } from 'react-redux';
 import { updateSort } from './toolbar/toolbarInputSlice';
+import { useAppDispatch } from '@hooks/useAppDispatch';
 
 interface SortDropdownProps {
   bgColor: string;
@@ -11,13 +11,12 @@ interface SortDropdownProps {
 
 const SortDropdown = ({ bgColor, width, height }: SortDropdownProps) => {
   const options = ['생성일순', '응답자순', '가까운 마감순'];
-  const optionToSort: { [key: string]: string } = {
+  const formOptionCodes: { [key: string]: string } = {
     생성일순: 'createdtime',
     응답자순: 'responseCnt',
     '가까운 마감순': 'endTime',
   };
-  const dispatch = useDispatch();
-
+  const dispatch = useAppDispatch();
   const [isOpen, setIsOpen] = useState(false);
   const [selectedOption, setSelectedOption] = useState(options[0]);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -28,7 +27,7 @@ const SortDropdown = ({ bgColor, width, height }: SortDropdownProps) => {
 
   const handleOptionClick = (option: string) => {
     setSelectedOption(option);
-    dispatch(updateSort({ sort: optionToSort[option] }));
+    dispatch(updateSort({ sort: formOptionCodes[option] }));
     setIsOpen(false);
   };
 

--- a/src/components/Myspace/questionBlock/QuestionBlock.tsx
+++ b/src/components/Myspace/questionBlock/QuestionBlock.tsx
@@ -79,15 +79,15 @@ const QuestionBlock = ({ questionData, dragHandler }: QuestionBlockProps) => {
           dispatch(setActiveBlockId({ id: questionData.id }));
         }
       }}
-      className="group/block p-6 relative w-full rounded-lg border border-transparent bg-white hover:bg-slate-50 focus-within:bg-slate-50  focus-within:border-slate-200"
+      className="relative w-full p-6 bg-white border border-transparent rounded-lg group/block hover:bg-slate-50 focus-within:bg-slate-50 focus-within:border-slate-200"
     >
       <div
         {...dragHandler}
-        className="invisible group-hover/block:visible flex absolute right-2 top-2 justify-center items-center w-6 h-6 text-neutral-400 text-sm font-bold p-2"
+        className="absolute flex items-center justify-center invisible w-6 h-6 p-2 text-sm font-bold group-hover/block:visible right-2 top-2 text-neutral-400"
       >
         ⸬
       </div>
-      <p className="text-xs font-bold  text-slate-500 mb-1">
+      <p className="mb-1 text-xs font-bold text-slate-500">
         {questionTypeLabels[questionData.type]}
       </p>
       <>
@@ -99,12 +99,12 @@ const QuestionBlock = ({ questionData, dragHandler }: QuestionBlockProps) => {
               <input
                 {...register('title')}
                 placeholder="질문을 입력해주세요."
-                className="text-lg w-full bg-transparent hover:bg-slate-100 outline-none border-b border-b-transparent focus:border-slate-300 focus:bg-slate-100 border-slate-300 placeholder:text-slate-400"
+                className="w-full text-lg bg-transparent border-b outline-none hover:bg-slate-100 border-b-transparent focus:border-slate-300 focus:bg-slate-100 border-slate-300 placeholder:text-slate-400"
               />
               <input
                 {...register('description')}
                 placeholder="질문에 대해 추가로 필요한 설명이나 제한사항을 입력하세요."
-                className="w-full bg-transparent outline-none border-b border-b-transparent  hover:bg-slate-100  focus:border-slate-300 focus:bg-slate-100 border-slate-300 placeholder:text-slate-400"
+                className="w-full bg-transparent border-b outline-none border-b-transparent hover:bg-slate-100 focus:border-slate-300 focus:bg-slate-100 border-slate-300 placeholder:text-slate-400"
               />
             </header>
             <section className="py-1 mb-4 text-slate-500">

--- a/src/components/Myspace/questionBlockList/QuestionBlockList.tsx
+++ b/src/components/Myspace/questionBlockList/QuestionBlockList.tsx
@@ -1,4 +1,4 @@
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { RootState } from '@/store';
 import QuestionBlock from '../questionBlock/QuestionBlock';
 import { reorderQuestion } from './questionBlockListSlice';
@@ -10,9 +10,10 @@ import {
   DroppableProvided,
   DropResult,
 } from 'react-beautiful-dnd';
+import { useAppDispatch } from '@hooks/useAppDispatch';
 
 const QuestionBlockList = () => {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const { questionList } = useSelector(
     (state: RootState) => state.questionBlockList
   );

--- a/src/hooks/useAppDispatch.ts
+++ b/src/hooks/useAppDispatch.ts
@@ -1,0 +1,4 @@
+import { useDispatch } from 'react-redux';
+import { AppDispatch } from '@/store';
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import questionBlockListReducer from '@/components/Myspace/questionBlockList/questionBlockListSlice';
 import questionBlockReducer from '@/components/Myspace/questionBlock/questionBlockSlice';
 import toolbarInputReducer from '@/components/Myspace/toolbar/toolbarInputSlice';
+import boardViewReducer from '@/components/Board/boardViewSlice';
 
 import { userApi } from '@api/userApi';
 import { activityApi } from '@/api/activityApi';
@@ -12,6 +13,7 @@ export const store = configureStore({
     questionBlockList: questionBlockListReducer,
     questionBlock: questionBlockReducer,
     toolbarInput: toolbarInputReducer,
+    boardView: boardViewReducer,
     [userApi.reducerPath]: userApi.reducer,
     [activityApi.reducerPath]: activityApi.reducer,
     [viewApi.reducerPath]: viewApi.reducer,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #71 

## 📝작업 내용

> board페이지 설문 리스트를 보여주는 페이지입니다. 사용자의 선택에 따라 적절한 설문 리스트를 보여줄 수 있도록 하기 위해 view API의 request 필드를 클라이언트 사이드 데이터로 관리합니다. 이를 위해 boardViewSlice를 설정하고 store에 등록하여 사용하였습니다. 
추가적으로 redux에서 제공하는 useDispatch훅 대신 이를 커스텀하여 useAppDispatch훅으로 사용하는것이 타입스크립트 환경에서 일반적이기 때문에 해당 훅을 생성하고, 기존 훅을 사용하는 부분에 대체하였습니다. 

## 💬리뷰 요구사항(선택)

> slice를 사용하는 부분은 문제가 없는 것을 확인하였습니다. 다만 두가지 측면에서 궁금한 지점이 발생했습니다. 
> 1. 위계가 비슷한 컴포넌트가 있는 경우 부모에서 dispatch와 리듀서를 한번에 선언해서 드릴링하는 형태가 일반적인지, 아니면 각 컴포넌트에서 새롭게 import 해서 사용하는 것이 일반적인지가 궁금합니다. 
> 2. 현재는 필드에 있는 값들을 하나의 필드 별로 리듀서를 만들어 변경하고 있습니다. 조금 불필요하게 길어지는 느낌이 있는데 더 나은 방법이 있는지 아시는 분은 알려주시면 감사하겠습니당 :)