### PR TITLE
FEAT/#84 nickname 관련 에러 핸들링

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -35,7 +35,7 @@ export default {
         line: '0.0625rem',
       },
       maxWidth: {
-        nicknamemodal: '30rem',
+        nicknamemodal: '25rem',
         homeFront: '34rem',
         surveyCard: '22.625rem',
       },


### PR DESCRIPTION
## #️⃣연관된 이슈

> #84 

## 📝작업 내용

> 현재 프로젝트 내에서 nickname을 변경하는 것과 관련된 api가 두개 있습니다. 
> 1. /v1/users/join
> 2. /v1/users
1번은 회원가입 시 닉네임을 받아 설정하는 api이고, 2번은 첫 닉네임 설정 이후 닉네임을 받아 설정하는 api입니다. 
현재 닉네임의 입력조건은 1글자 이상 입니다. 현재 에러 코드로 다루고 있는 에러 핸들링은 중복 닉네임 관련 에러 입니다. 이외에는 api request 전에 프론트 단에서 핸들링 해서 해결합니다. 현재 백엔드 인원들과 협의하여 닉네임 컨벤션 관련 이야기를 나누고 있고, 확정된 내용은 다음과 같습니다.
> 1. 앞 뒤 공백은 제거
> 2. 글자 사이 공백은 1개만 유지
이를 바탕으로 정규표현식을 작성하여 닉네임 입력 조건을 검사하였습니다.

## 💬리뷰 요구사항

> trim 메서드를 이용해서 공백을 제거했습니다. 이후 닉네임 컨벤션이 확정되면 이를 정규표현식화 하여 적용할 예정입니다. 
