### PR TITLE
Feat/#89 form response block

### DIFF
--- a/src/components/AutoResizeTextarea.tsx
+++ b/src/components/AutoResizeTextarea.tsx
@@ -1,0 +1,38 @@
+import { FieldValues, Path, UseFormRegister } from 'react-hook-form';
+
+interface AutoResizeTextareaProps<T extends FieldValues> {
+  register: UseFormRegister<T>;
+  fieldName: Path<T>;
+  placeholder: string;
+  className: string;
+}
+
+const AutoResizeTextarea = <T extends Record<string, unknown>>({
+  register,
+  fieldName,
+  placeholder = '',
+  className = '',
+}: AutoResizeTextareaProps<T>) => {
+  const { ref, ...rest } = register(fieldName);
+  const adjustHeight = (element: HTMLTextAreaElement) => {
+    element.style.height = '0';
+    element.style.height = `${element.scrollHeight}px`;
+  };
+
+  return (
+    <textarea
+      ref={(element) => {
+        ref(element);
+        if (element) {
+          adjustHeight(element);
+        }
+      }}
+      {...rest}
+      placeholder={placeholder}
+      className={`overflow-hidden resize-none outline-none ${className}`}
+      onInput={(e) => adjustHeight(e.currentTarget)}
+    />
+  );
+};
+
+export default AutoResizeTextarea;

--- a/src/components/Form/DescriptionBlock.tsx
+++ b/src/components/Form/DescriptionBlock.tsx
@@ -1,0 +1,7 @@
+const DescriptionBlock = ({ description }: { description: string }) => {
+  return (
+    <p className="bg-slate-100 text-slate-500 p-8 rounded-lg">{description}</p>
+  );
+};
+
+export default DescriptionBlock;

--- a/src/components/Form/DropdownInput.tsx
+++ b/src/components/Form/DropdownInput.tsx
@@ -1,0 +1,28 @@
+import { Content } from '@/pages/Form';
+import { UseFormRegister } from 'react-hook-form';
+
+// TODO:form 제출 field interface 정해지면 any적용
+interface DropdownInputProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  register: UseFormRegister<any>;
+  questionData: Content;
+}
+
+// TODO: 커스텀 드롭다운으로 변경
+const DropdownInput = ({ register, questionData }: DropdownInputProps) => {
+  const options = questionData.options;
+  return (
+    <select
+      {...register('selectedOption')}
+      className="appearance-none p-2 border-2 rounded-lg focus:outline-slate-400"
+    >
+      <option value="none">선택하세요.</option>
+      {options?.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.value}
+        </option>
+      ))}
+    </select>
+  );
+};
+export default DropdownInput;

--- a/src/components/Form/FormBody.tsx
+++ b/src/components/Form/FormBody.tsx
@@ -3,6 +3,7 @@ import AutoResizeTextarea from '../AutoResizeTextarea';
 import { useForm } from 'react-hook-form';
 import DropdownInput from './DropdownInput';
 import MultiOptionInput from './MultiOptionInput';
+import DescriptionBlock from './DescriptionBlock';
 
 interface FormBodyProps {
   questions: Content[];
@@ -41,22 +42,26 @@ const FormBody = ({ questions }: FormBodyProps) => {
         );
       case 'dropdown':
         return <DropdownInput register={register} questionData={question} />;
-      case 'text':
-        return <div></div>;
     }
   };
 
   return (
-    <div className="px-4">
+    <div className="flex flex-col gap-12 px-4 py-10 bg-white">
       {questions.map((question) => (
-        <div key={question.id} className="px-4 pb-4 flex flex-col gap-4">
-          <div className="pt-10 pb-2">
-            <h1 className="text-xl font-semibold text-slate-700 mb-1">
-              {question.title}
-            </h1>
-            <p className="text-slate-500">{question.description}</p>
-          </div>
-          {renderResponseInput(question)}
+        <div key={question.id} className="p-4 flex flex-col gap-4">
+          {question.type === 'text' ? (
+            <DescriptionBlock description={question.description as string} />
+          ) : (
+            <>
+              <div className="pb-2">
+                <h1 className="text-lg text-slate-700 mb-1">
+                  {question.title}
+                </h1>
+                <p className="text-sm text-slate-500">{question.description}</p>
+              </div>
+              {renderResponseInput(question)}
+            </>
+          )}
         </div>
       ))}
     </div>

--- a/src/components/Form/FormBody.tsx
+++ b/src/components/Form/FormBody.tsx
@@ -56,6 +56,9 @@ const FormBody = ({ questions }: FormBodyProps) => {
               <div className="pb-2">
                 <h1 className="text-lg text-slate-700 mb-1">
                   {question.title}
+                  {question.isRequired && (
+                    <span className="text-red-500 ml-1 text-lg">*</span>
+                  )}
                 </h1>
                 <p className="text-sm text-slate-500">{question.description}</p>
               </div>

--- a/src/components/Form/FormBody.tsx
+++ b/src/components/Form/FormBody.tsx
@@ -1,5 +1,66 @@
-const FormBody = () => {
-  return <div>formbody</div>;
+import { Content } from '@/pages/Form';
+import AutoResizeTextarea from '../AutoResizeTextarea';
+import { useForm } from 'react-hook-form';
+import DropdownInput from './DropdownInput';
+import MultiOptionInput from './MultiOptionInput';
+
+interface FormBodyProps {
+  questions: Content[];
+}
+
+const FormBody = ({ questions }: FormBodyProps) => {
+  const { register } = useForm();
+
+  const renderResponseInput = (question: Content) => {
+    switch (question.type) {
+      case 'short':
+      case 'long':
+        return (
+          <AutoResizeTextarea
+            register={register}
+            fieldName="textInput"
+            placeholder={question.type === 'short' ? '단답형' : '장문형'}
+            className="p-2 text-slate-700 focus:border-slate-400 border-b-2 focus:bg-slate-100"
+          />
+        );
+      case 'single':
+        return (
+          <MultiOptionInput
+            type="single"
+            register={register}
+            questionData={question}
+          />
+        );
+      case 'checkbox':
+        return (
+          <MultiOptionInput
+            type="checkbox"
+            register={register}
+            questionData={question}
+          />
+        );
+      case 'dropdown':
+        return <DropdownInput register={register} questionData={question} />;
+      case 'text':
+        return <div></div>;
+    }
+  };
+
+  return (
+    <div className="px-4">
+      {questions.map((question) => (
+        <div key={question.id} className="px-4 pb-4 flex flex-col gap-4">
+          <div className="pt-10 pb-2">
+            <h1 className="text-xl font-semibold text-slate-700 mb-1">
+              {question.title}
+            </h1>
+            <p className="text-slate-500">{question.description}</p>
+          </div>
+          {renderResponseInput(question)}
+        </div>
+      ))}
+    </div>
+  );
 };
 
 export default FormBody;

--- a/src/components/Form/FormHeader.tsx
+++ b/src/components/Form/FormHeader.tsx
@@ -39,7 +39,7 @@ const FormHeader = ({ formData }: FormHeaderProps) => {
       </div>
       <div className="flex flex-col gap-1">
         <div className="flex items-center gap-3">
-          <h1 className="text-2xl font-bold ">{title}</h1>
+          <h1 className="text-2xl font-bold text-slate-700 ">{title}</h1>
           <p className="text-slate-500 text-xs bg-slate-100 p-1">
             <span className="font-bold">{formattedDate}</span> 배포됨
             <span className="font-bold ml-2">

--- a/src/components/Form/FormHeader.tsx
+++ b/src/components/Form/FormHeader.tsx
@@ -21,7 +21,7 @@ const FormHeader = ({ formData }: FormHeaderProps) => {
   const dateObject = new Date(startDate);
   const formattedDate = `${dateObject.getFullYear()}/${String(dateObject.getMonth() + 1).padStart(2, '0')}/${String(dateObject.getDate()).padStart(2, '0')}`;
   return (
-    <div className="p-8 text-slate-500">
+    <div className="p-8 text-slate-500 bg-white">
       <div className="flex justify-between jus mb-4">
         <div className="text-xs bg-slate-100 px-2 py-1">
           <p>질문 {questionCnt}문항</p>

--- a/src/components/Form/MultiOptionInput.tsx
+++ b/src/components/Form/MultiOptionInput.tsx
@@ -20,7 +20,7 @@ const MultiOptionInput = ({
       {options?.map((option) => (
         <div
           key={option.id}
-          className="flex px-4 py-2 gap-4 items-center hover:bg-slate-100"
+          className="flex px-4 py-2 gap-4 items-center rounded-lg hover:bg-slate-100"
         >
           <div className="flex items-center">
             <input

--- a/src/components/Form/MultiOptionInput.tsx
+++ b/src/components/Form/MultiOptionInput.tsx
@@ -1,0 +1,40 @@
+import { Content } from '@/pages/Form';
+import { UseFormRegister } from 'react-hook-form';
+
+// TODO:form 제출 field interface 정해지면 any적용
+interface MultiOptionInputProps {
+  type: 'single' | 'checkbox';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  register: UseFormRegister<any>;
+  questionData: Content;
+}
+
+const MultiOptionInput = ({
+  type,
+  register,
+  questionData,
+}: MultiOptionInputProps) => {
+  const options = questionData.options;
+  return (
+    <div className="flex flex-col gap-2">
+      {options?.map((option) => (
+        <div
+          key={option.id}
+          className="flex px-4 py-2 gap-4 items-center hover:bg-slate-100"
+        >
+          <div className="flex items-center">
+            <input
+              {...register('selectedOption')}
+              type={type === 'single' ? 'radio' : 'checkbox'}
+              id={`option-${option.id}`}
+              value={option.value}
+              className="appearance-none border-4 rounded-full w-4 h-4 checked:border-slate-400"
+            />
+          </div>
+          <label htmlFor={`option-${option.id}`}>{option.value}</label>
+        </div>
+      ))}
+    </div>
+  );
+};
+export default MultiOptionInput;

--- a/src/pages/Form.tsx
+++ b/src/pages/Form.tsx
@@ -30,8 +30,8 @@ export interface Content {
   title?: string;
   description?: string;
   options?: Option[];
-  isRequired: boolean;
-  isPrivacy: boolean;
+  isRequired?: boolean;
+  isPrivacy?: boolean;
 }
 
 export interface Form {
@@ -96,9 +96,15 @@ const dummy = {
     },
     {
       id: 2,
+      type: 'text' as QuestionType,
+      description:
+        '신중하게답변해주실래요 아래질문은 절망 중요하니까요이이이이이이',
+    },
+    {
+      id: 3,
       type: 'short' as QuestionType,
       title: '두번째루 질문드리고싶은건요',
-      description: '딱히 없어요',
+      description: '',
       options: [],
       isRequired: false,
       isPrivacy: false,
@@ -129,13 +135,13 @@ const dummy = {
 
 const Form = () => {
   return (
-    <div className="bg-slate-50 min-h-screen">
+    <div className="bg-slate-100 min-h-screen">
       <img
         src={dummy.image[0]}
         alt="thumbnail"
         className="w-full h-24 object-cover"
       />
-      <div className="max-w-[832px] flex flex-col mx-auto bg-white">
+      <div className="max-w-[832px] flex flex-col gap-2 mx-auto">
         <FormHeader formData={dummy} />
         <FormBody questions={dummy.contents} />
       </div>

--- a/src/pages/Form.tsx
+++ b/src/pages/Form.tsx
@@ -24,7 +24,7 @@ interface Option {
   value: string;
 }
 
-interface Content {
+export interface Content {
   id: number;
   type: QuestionType;
   title?: string;
@@ -71,15 +71,35 @@ const dummy = {
   contents: [
     {
       id: 1,
-      type: 'single' as QuestionType,
+      type: 'dropdown' as QuestionType,
       title: '첫번째루 질문드리고싶은건요',
       description: '딱히 없어요',
       options: [
         {
           id: 1,
-          value: 'dddd',
+          value:
+            '자전거 도둑, 달걀은 달걀로 갚으렴, 시인의 꿈, 옥상의 민들레꽃, 할머니는 우리 편, 마지막 임금님 작중 수남을 귀여워해주는 손님 중 하나가 야학이라도 다녀볼 생각 없냐라고 한 게 공부를 하기 시작한 계기가 저 시간만 있으면 책이라고라며 손님들에게애ㅍ',
+        },
+        {
+          id: 2,
+          value:
+            '자전거 도둑, 달걀은 달걀로 갚으렴, 시인의 꿈, 옥상의 민들레꽃, 할머니는 우리 편, 마지막 임금님 작중 수남을 귀여워해주는 손님 중 하나가 야학이라도 다녀볼 생각 없냐라고',
+        },
+        {
+          id: 3,
+          value:
+            '자전거 도둑, 마지막 임금님 작중 수남을 귀여워해주는 손님 중 하나가 야학이',
         },
       ],
+      isRequired: false,
+      isPrivacy: false,
+    },
+    {
+      id: 2,
+      type: 'short' as QuestionType,
+      title: '두번째루 질문드리고싶은건요',
+      description: '딱히 없어요',
+      options: [],
       isRequired: false,
       isPrivacy: false,
     },
@@ -117,7 +137,7 @@ const Form = () => {
       />
       <div className="max-w-[832px] flex flex-col mx-auto bg-white">
         <FormHeader formData={dummy} />
-        <FormBody />
+        <FormBody questions={dummy.contents} />
       </div>
     </div>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

#89 

## 📝작업 내용

- 설문 응답 페이지의 질문타입별 UI를 제작했습니다.
- `single`타입과 `checkbox`타입은`MultiOptionInput`으로 추상화하였고 `short`와 `long`은 전역에서 사용할 수 있는 `AutoSizeTextarea`로 사용하였습니다. 기존에 폼 제작 시 사용하던 `TextBlock`를 추상화한 것으로, 추후 리팩터링에서 `TextBlock` 또한 `AutoSizeTextarea`로 대체할 예정입니다. 
- 일부 디자인이 안나온 부분이 많아서 임의로 작업하였고, 제출 버튼 부분은 오늘 중으로 디자인 요청드렸으니 추가되는대로 적용하겠습니다.


### 스크린샷 (선택)
<img width="1792" alt="스크린샷 2024-05-08 14 04 06" src="https://github.com/SSA-FE/formssafe-fe/assets/100757599/a72b7e12-70ea-4cbd-9062-ca45f9bb02c3">



## 추후 작업계획
- API연결
- 내가 쓴 설문일 경우 제출 하지 않도록 수정